### PR TITLE
Fix release failure from casing

### DIFF
--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -26,5 +26,5 @@ jobs:
         with:
           push: true
           tags: |
-            ghcr.io/Autumn-Martin/gopher-a-tweet:${{ env.RELEASE_VERSION }}
-            ghcr.io/Autumn-Martin/gopher-a-tweet:latest
+            ghcr.io/autumn-martin/gopher-a-tweet:${{ env.RELEASE_VERSION }}
+            ghcr.io/autumn-martin/gopher-a-tweet:latest


### PR DESCRIPTION
Fixes an error that appeared [during the first release](
https://github.com/Autumn-Martin/gopher-a-tweet/runs/4474419039?check_suite_focus=true) for the tag being
invalid because the repo name must be lowercase:
> Error: buildx failed with: error: invalid tag "ghcr.io/Autumn-Martin/gopher-a-tweet:1.0.0": repository name must be lowercase