### PR TITLE
Speed up gophering a tweet

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -24,9 +24,7 @@ outputs:
     description: 'message sent to Twitter'
 runs:
   using: docker
-  image: Dockerfile
-#  using: docker
-#  image: docker://ghcr.io/Autumn-Martin/gopher-a-tweet:1.0.0
+  image: docker://ghcr.io/autumn-martin/gopher-a-tweet:1.0.0
   args:
     - --message
     - "${{ inputs.message }}"


### PR DESCRIPTION
Testing the action with a dry run has been slow, because building an
image can take a minute. This update uses the docker image for the most
recent release, v1.0.0, instead of building a new image every run.

![](https://media.giphy.com/media/S6BLhq4ZOvIdN0WVEQ/giphy.gif)