### PR TITLE
Bring back speed boost

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -24,7 +24,7 @@ outputs:
     description: 'message sent to Twitter'
 runs:
   using: docker
-  image: Dockerfile
+  image: docker://ghcr.io/autumn-martin/gopher-a-tweet:1.0.0
   args:
     - --message
     - "${{ inputs.message }}"


### PR DESCRIPTION
Bring back boost after seeing the impact on pushing a new release
without it.

This action is slow if we build a new docker image every time. We can
get a speed boost by using the most recent stable release image,
image-v1.0.0, instead of building a new image every run.

Without speed boost:
<img width="1089" alt="Screen Shot 2021-12-09 at 8 43 58 PM" src="https://user-images.githubusercontent.com/36902512/145514560-91ab89d1-18bf-4f7b-a6c9-57d4211edeca.png">

With speed boost:
<img width="1093" alt="Screen Shot 2021-12-09 at 8 44 48 PM" src="https://user-images.githubusercontent.com/36902512/145514552-f0866854-a1f6-4711-a3e8-9e313c596a66.png">
